### PR TITLE
Release 1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the library as a dependency to your app's `build.gradle` file
 ```groovy  
 dependencies {  
     //....  
-    implementation "com.nerdstone:neat-form-core:"  
+    implementation "com.nerdstone:neat-form-core:1.1.6"  
    //....  
   
 }  
@@ -88,7 +88,7 @@ Add the library in the dependency section of your application's `build.gradle` f
 ```groovy  
 dependencies {  
    //consume library - use the latest version available on github packages  
-   implementation "com.nerdstone:neat-form-core:"  
+   implementation "com.nerdstone:neat-form-core:1.1.6"  
    //....  
   
 }  


### PR DESCRIPTION
This PR aligns master with the 1.1.6 release tag.\n\n- VERSION_NAME=1.1.6 in gradle.properties\n- README dependency snippets set to 1.1.6\n- CHANGELOG.md includes v1.1.6 notes\n- Managed JitPack badges block present (Latest, tag, master-SNAPSHOT)\n\nAfter merge, badges workflow will keep the tag badge up to date and ping JitPack to prime builds.